### PR TITLE
Add newrelic dependency and a script to export required env vars

### DIFF
--- a/minionsApi.cabal
+++ b/minionsApi.cabal
@@ -54,6 +54,7 @@ executable minionsApi
   -- Other library packages from which modules are imported.
   build-depends: base
                , warp
+               , helics
                , minionsApi
 
   -- Directories containing source files.
@@ -96,6 +97,7 @@ library
                      , transformers
                      , monad-control
                      , heroku-persistent
+                     , helics
 
 Test-Suite test
   type:                exitcode-stdio-1.0

--- a/scripts/newrelic-env.sh
+++ b/scripts/newrelic-env.sh
@@ -1,0 +1,3 @@
+export LD_LIBRARY_PATH=/usr/local/lib
+export SDK_INCLUDE_DIR=/usr/local/include
+export SDK_LIB_DIR=/usr/local/lib

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -6,6 +6,7 @@ import MinionsApi.Service      (app)
 import MinionsApi.Middlewares  (allowCsrf, corsified)
 import MinionsApi.Config       (defaultConfig, Config(..), Environment(..), setLogger, makePool, lookupSetting)
 import MinionsApi.Schema       (runMigrations)
+import Network.Helics
 
 main :: IO ()
 main = do


### PR DESCRIPTION
Tested on OS X. `dummy` flag for helics seems to be working.
